### PR TITLE
Nested .row (for code examples) need r/l padding

### DIFF
--- a/scss/_theme_layout.scss
+++ b/scss/_theme_layout.scss
@@ -5,6 +5,10 @@
     max-width: 100%;
     padding: 0;
     width: 100%;
+
+    & & { // Nested .rows (for code examples) need right/left padding
+      padding: 0 $grid-gutter-width;
+    }
   }
 
   .theme {


### PR DESCRIPTION
This fix makes sure that `.row` containers used in the examples throughout the docs behave as expected.

Fixes https://github.com/ubuntudesign/vanilla-framework/issues/646
