### PR TITLE
Isolate theme overrides to theme layout

### DIFF
--- a/scss/_pattern_footer.scss
+++ b/scss/_pattern_footer.scss
@@ -1,7 +1,7 @@
 
 @mixin p-footer {
 
-  .p-footer {
+  .theme > .p-footer {
     border-top: 1px solid $color-mid-grey;
     color: $color-mid-grey;
     padding: 1rem;

--- a/scss/_pattern_navigation.scss
+++ b/scss/_pattern_navigation.scss
@@ -1,7 +1,7 @@
 
 @mixin p-navigation {
 
-  .p-navigation {
+  .theme > .p-navigation {
     background: $color-light;
     border-bottom: 1px solid $color-mid-grey;
     color: $color-cool-grey;


### PR DESCRIPTION
## Done
- Theme pattern overrides should not affect display of core vanilla patterns in main content area
## QA
- Check that docs theme header/footer are distinct from Vanilla examples in vf.io
