### PR TITLE
Tweaks to layout

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -155,9 +155,6 @@
                           <a class="p-sidebar-nav__link" href="#23">Solor sit</a>
                         </li>
                       </ul>
-                <section class="p-sidebar-nav__top">
-                    <a href="#">Back to top</a>
-                </section>
             </nav>
         </div>
             <div class="col-7 p-layout__main">
@@ -176,7 +173,7 @@
                             <li>Unordered list item 5 <a href="#">with link</a></li>
                         </ul>
 
-                        <h2>Heading two</h2>
+                        <h2 id="heading-two">Heading two</h2>
                         <p>Laborum omnis doloremque soluta atque, veniam laudantium quae:</p>
 <pre class="language-bash"><code class="language-bash"><span class="token function">multi</span>
 <span class="token operator">-</span>line
@@ -214,21 +211,24 @@
                             ipsa officiis laboriosam facilis modi quo.
                             <cite>Officiis Laboriosam<cite>
                         </blockquote>
+
+                        <h2 id="another-heading-two">Another heading two</h2>
+                        <p>Laborum omnis doloremque soluta atque, veniam laudantium quae:</p>
                     </main>
             </div>
-            <aside class="col-2 p-layout__aside">
-                <div class="p-toc">
-                    <h4 class="p-toc__header">Contents</h4>
+            <aside class="col-2 p-aside">
+                <div class="p-aside__section">
+                    <h4 class="p-aside__header">Contents</h4>
                     <nav>
-                        <ol class="p-toc__list">
+                        <ol class="p-toc">
                             <li>
-                                <a href="#installation">Installation</a>
+                                <a href="#heading-two">Heading two</a>
                             </li>
                             <li>
-                                <a href="#configuring">Configuring</a>
+                                <a href="#another-heading-two">Another heading two</a>
                             </li>
                             <li>
-                                <a href="#testing-your-setup">Testing your setup</a>
+                                <a href="#">Back to top</a>
                             </li>
                         </ol>
                     </nav>

--- a/scss/_patterns_aside.scss
+++ b/scss/_patterns_aside.scss
@@ -1,0 +1,31 @@
+@mixin docs-p-aside {
+  .p-aside {
+    align-self: flex-start;
+    border-top: 1px solid $color-mid-light;
+    flex: 0 0 16em;
+    font-size: .875rem;
+    padding: 0 1rem;
+
+    @media (min-width: $breakpoint-medium) {
+      border-left: 1px solid $color-mid-light;
+      border-top: 0;
+      margin-top: 6rem;
+      padding: 0 2rem;
+    }
+
+    &__header {
+      color: $color-mid-dark;
+      font-size: 1em;
+      margin-bottom: .5rem;
+      text-transform: uppercase;
+    }
+
+    &__section {
+      padding: 1.5rem 0;
+
+      &:not(:last-child) {
+        border-bottom: 1px dotted $color-mid-light;
+      }
+    }
+  }
+}

--- a/scss/_patterns_footer.scss
+++ b/scss/_patterns_footer.scss
@@ -5,7 +5,7 @@
   @include vf-p-footer;
 
   .p-footer {
-    border-top: 1px solid $color-mid-dark;
+    border-top: 1px solid $color-mid-light;
     color: $color-mid-dark;
     padding: 1rem;
 

--- a/scss/_patterns_layout.scss
+++ b/scss/_patterns_layout.scss
@@ -15,12 +15,12 @@
     &__main {
       display: flex;
       flex: 1;
-      padding: 0 1rem;
+      padding: 1.5rem 1rem 0 1rem;
 
       @media (min-width: $breakpoint-medium) {
         border-left: 1px solid $color-mid-light;
         margin-left: 0;
-        padding: 1rem 1.5rem;
+        padding: 2rem;
       }
     }
 

--- a/scss/_patterns_layout.scss
+++ b/scss/_patterns_layout.scss
@@ -35,11 +35,6 @@
       width: 100%;
     }
 
-    &__aside {
-      padding: 1.75rem 1rem;
-    }
-
-    &__aside,
     &__sidebar {
       flex: 0 0 16em;
     }

--- a/scss/_patterns_layout.scss
+++ b/scss/_patterns_layout.scss
@@ -18,7 +18,7 @@
       padding: 0 1rem;
 
       @media (min-width: $breakpoint-medium) {
-        border-left: 1px solid $color-mid-dark;
+        border-left: 1px solid $color-mid-light;
         margin-left: 0;
         padding: 1rem 1.5rem;
       }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -25,15 +25,15 @@
 
     &__logo {
       color: $color-dark;
-      margin-top: 0;
       margin-bottom: 0;
+      margin-top: 0;
     }
 
     &__image {
-      height: 32px;
-      margin: 0 1rem 0 0;
       display: block;
       float: left;
+      height: 32px;
+      margin: 0 1rem 0 0;
       vertical-align: middle;
     }
   }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -8,7 +8,7 @@
 
   .p-navigation {
     background: $color-x-light;
-    border-bottom: 1px solid $color-mid-dark;
+    border-bottom: 1px solid $color-mid-light;
     color: $color-dark;
     line-height: 32px;
     padding: 7.5px 0;

--- a/scss/_patterns_sidebar-nav.scss
+++ b/scss/_patterns_sidebar-nav.scss
@@ -62,7 +62,7 @@
 
 
     &__group {
-      border-bottom: 1px dotted $color-mid-dark;
+      border-bottom: 1px dotted $color-mid-light;
       margin: 0;
       padding: 1rem;
 

--- a/scss/_patterns_toc.scss
+++ b/scss/_patterns_toc.scss
@@ -1,22 +1,8 @@
 // Table of contents pattern
 @mixin docs-p-toc {
   .p-toc {
-    @media (min-width: $breakpoint-medium) {
-      border-left: 1px solid $color-dark;
-      padding-left: 1rem;
-    }
-
-    &__header {
-      color: $color-mid-dark;
-      font-size: .875rem;
-      margin-bottom: .5rem;
-      text-transform: uppercase;
-    }
-
-    &__list {
-      list-style: none;
-      margin: 0;
-      padding: 0 0 1rem;
-    }
+    list-style: none;
+    margin: 0;
+    padding: 0;
   }
 }

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -21,6 +21,7 @@
 
 // import theme patterns
 @import 'base_code';
+@import 'patterns_aside';
 @import 'patterns_layout';
 @import 'patterns_navigation';
 @import 'patterns_footer';
@@ -45,6 +46,7 @@
 
   // Theme patterns
   @include docs-b-code;
+  @include docs-p-aside;
   @include docs-p-layout;
   @include docs-p-footer;
   @include docs-p-grid;


### PR DESCRIPTION
- Extract generic part of `p-toc` into `p-aside`, so we can have other aside content apart from table of contents
- Increase spacing around main content, in both desktop and mobile
- Changes from #35:
  - Make all the lines lighter
  - Align aside content with main body content - below the heading
  - Change aside font-size to 14px
  - Increase space between the separating line and the aside content

QA
--

`npm i`, `gulp build`, open `demo/index.html` and see that the items mentioned above have changed, and nothing else has changed. Check small screen as well.