### PR TITLE
Add breadcrumbs for small screen

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -155,6 +155,10 @@
                       </ul>
             </nav>
         </div>
+        <nav class="p-breadcrumbs">
+            <a class="p-breadcrumbs__link" href="#">Parent page</a>
+            <span class="p-breadcrumbs__link--active">This page</span>
+        </nav>
             <div class="col-7 p-layout__main">
                 <main id="main-content" class="p-layout__inner">
                         <h1>Heading one</h1>

--- a/demo/index.html
+++ b/demo/index.html
@@ -155,9 +155,6 @@
                           <a class="p-sidebar-nav__link" href="#23">Solor sit</a>
                         </li>
                       </ul>
-                <section class="p-sidebar-nav__top">
-                    <a href="#">Back to top</a>
-                </section>
             </nav>
         </div>
             <div class="col-7 p-layout__main">
@@ -176,7 +173,7 @@
                             <li>Unordered list item 5 <a href="#">with link</a></li>
                         </ul>
 
-                        <h2>Heading two</h2>
+                        <h2 id="heading-two">Heading two</h2>
                         <p>Laborum omnis doloremque soluta atque, veniam laudantium quae:</p>
 <pre class="language-bash"><code class="language-bash"><span class="token function">multi</span>
 <span class="token operator">-</span>line
@@ -214,21 +211,24 @@
                             ipsa officiis laboriosam facilis modi quo.
                             <cite>Officiis Laboriosam<cite>
                         </blockquote>
+
+                        <h2 id="another-heading-two">Another heading two</h2>
+                        <p>Laborum omnis doloremque soluta atque, veniam laudantium quae:</p>
                     </main>
             </div>
-            <aside class="col-2 p-layout__aside">
-                <div class="p-toc">
-                    <h4 class="p-toc__header">Contents</h4>
+            <aside class="col-2 p-aside">
+                <div class="p-aside__section">
+                    <h4 class="p-aside__header">Contents</h4>
                     <nav>
-                        <ol class="p-toc__list">
+                        <ol class="p-toc">
                             <li>
-                                <a href="#installation">Installation</a>
+                                <a href="#heading-two">Heading two</a>
                             </li>
                             <li>
-                                <a href="#configuring">Configuring</a>
+                                <a href="#another-heading-two">Another heading two</a>
                             </li>
                             <li>
-                                <a href="#testing-your-setup">Testing your setup</a>
+                                <a href="#">Back to top</a>
                             </li>
                         </ol>
                     </nav>

--- a/demo/index.html
+++ b/demo/index.html
@@ -24,12 +24,11 @@
             <nav class="p-sidebar-nav">
                 <ul class="p-sidebar-nav__list">
                     <li class="p-sidebar-nav__group">
-                        <a href="#section1">
-                            <h4 class="p-sidebar-nav__header">
-                                <img class="p-sidebar-nav__toggle--collapse" src="https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg" />
-                                Section title 1
-                            </h4>
-                        </a>
+                        <h4 class="p-sidebar-nav__header">
+                            <img class="p-sidebar-nav__toggle--collapse" src="https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg" />
+                            Section title 1
+                        </h4>
+
                         <section id="section1" class="p-sidebar-nav__section">
                             <ul class="p-sidebar-nav__list">
                                 <li>
@@ -45,12 +44,11 @@
                         </section>
                     </li>
                     <li class="p-sidebar-nav__group">
-                        <a href="#section2">
-                            <h4 class="p-sidebar-nav__header">
-                                <img class="p-sidebar-nav__toggle--expand" src="https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg" />
-                                Section title 2
-                            </h4>
-                        </a>
+                        <h4 class="p-sidebar-nav__header">
+                            <img class="p-sidebar-nav__toggle--expand" src="https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg" />
+                            Section title 2
+                        </h4>
+
                         <section id="section2" class="p-sidebar-nav__section--collapsed">
                             <ul class="p-sidebar-nav__list">
                                 <li>
@@ -72,9 +70,8 @@
                         </section>
                     </li>
                     <li class="p-sidebar-nav__group">
-                        <a href="#section3">
-                            <h4 class="p-sidebar-nav__header">Section title 3</h4>
-                        </a>
+                        <h4 class="p-sidebar-nav__header">Section title 3</h4>
+
                         <section id="section3" class="p-sidebar-nav__section">
                             <ul class="p-sidebar-nav__list">
                                 <li>
@@ -102,9 +99,10 @@
 
                         </li>
                         <li class="p-sidebar-nav__group">
-                            <a href="#section4">
-                                <h4 class="p-sidebar-nav__header">Section title 4</h4>
-                            </a>
+                            <h4 class="p-sidebar-nav__header">
+                              <a class="p-sidebar-nav__link" href="#section4">Section title 4</a>
+                            </h4>
+
                             <section id="section4" class="p-sidebar-nav__section">
                                 <ul class="p-sidebar-nav__list">
                                     <li>
@@ -222,13 +220,13 @@
                     <nav>
                         <ol class="p-toc">
                             <li>
-                                <a href="#heading-two">Heading two</a>
+                                <a class="p-toc__link" href="#heading-two">Heading two</a>
                             </li>
                             <li>
-                                <a href="#another-heading-two">Another heading two</a>
+                                <a class="p-toc__link" href="#another-heading-two">Another heading two</a>
                             </li>
                             <li>
-                                <a href="#">Back to top</a>
+                                <a class="p-toc__link" href="#">Back to top</a>
                             </li>
                         </ol>
                     </nav>

--- a/scss/_base_links.scss
+++ b/scss/_base_links.scss
@@ -1,0 +1,33 @@
+@mixin docs-b-links {
+  a {
+    border-bottom: 0;
+    color: $link-color;
+    font-weight: inherit;
+
+    &:visited {
+      color: $link-color;
+    }
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  h1 a,
+  h2 a,
+  h3 a,
+  h4 a,
+  h5 a,
+  h6 a {
+    color: $text-color;
+    font-weight: normal;
+
+    &:visited {
+      color: $text-color;
+    }
+
+    &:hover {
+      color: $link-color;
+    }
+  }
+}

--- a/scss/_patterns_aside.scss
+++ b/scss/_patterns_aside.scss
@@ -1,0 +1,31 @@
+@mixin docs-p-aside {
+  .p-aside {
+    align-self: flex-start;
+    border-top: 1px solid $color-mid-light;
+    flex: 0 0 16em;
+    font-size: .875rem;
+    padding: 0 1rem;
+
+    @media (min-width: $breakpoint-medium) {
+      border-left: 1px solid $color-mid-light;
+      border-top: 0;
+      margin-top: 6rem;
+      padding: 0 2rem;
+    }
+
+    &__header {
+      color: $color-mid-dark;
+      font-size: 1em;
+      margin-bottom: .5rem;
+      text-transform: uppercase;
+    }
+
+    &__section {
+      padding: 1.5rem 0;
+
+      &:not(:last-child) {
+        border-bottom: 1px dotted $color-mid-light;
+      }
+    }
+  }
+}

--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -1,0 +1,36 @@
+@import 'vanilla-framework/scss/patterns_breadcrumbs';
+
+@mixin docs-p-breadcrumbs {
+  @include vf-p-breadcrumbs;
+
+  .p-breadcrumbs {
+    display: block;
+    margin-left: 1rem;
+    margin-top: 1rem;
+
+    &__link {
+      color: $text-color;
+      font-weight: 300;
+
+      &:visited {
+        color: $text-color;
+      }
+
+      &:hover {
+        color: $link-color;
+      }
+
+      &--active {
+        font-weight: normal;
+
+        &:hover {
+          color: $text-color;
+        }
+      }
+    }
+
+    @media (min-width: $breakpoint-medium) {
+      display: none;
+    }
+  }
+}

--- a/scss/_patterns_footer.scss
+++ b/scss/_patterns_footer.scss
@@ -5,7 +5,7 @@
   @include vf-p-footer;
 
   .p-footer {
-    border-top: 1px solid $color-mid-dark;
+    border-top: 1px solid $color-mid-light;
     color: $color-mid-dark;
     padding: 1rem;
 

--- a/scss/_patterns_layout.scss
+++ b/scss/_patterns_layout.scss
@@ -15,12 +15,12 @@
     &__main {
       display: flex;
       flex: 1;
-      padding: 0 1rem;
+      padding: 1.5rem 1rem 0 1rem;
 
       @media (min-width: $breakpoint-medium) {
         border-left: 1px solid $color-mid-light;
         margin-left: 0;
-        padding: 1rem 1.5rem;
+        padding: 2rem;
       }
     }
 

--- a/scss/_patterns_layout.scss
+++ b/scss/_patterns_layout.scss
@@ -35,11 +35,6 @@
       width: 100%;
     }
 
-    &__aside {
-      padding: 1.75rem 1rem;
-    }
-
-    &__aside,
     &__sidebar {
       flex: 0 0 16em;
     }

--- a/scss/_patterns_layout.scss
+++ b/scss/_patterns_layout.scss
@@ -18,7 +18,7 @@
       padding: 0 1rem;
 
       @media (min-width: $breakpoint-medium) {
-        border-left: 1px solid $color-mid-dark;
+        border-left: 1px solid $color-mid-light;
         margin-left: 0;
         padding: 1rem 1.5rem;
       }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -25,15 +25,15 @@
 
     &__logo {
       color: $color-dark;
-      margin-top: 0;
       margin-bottom: 0;
+      margin-top: 0;
     }
 
     &__image {
-      height: 32px;
-      margin: 0 1rem 0 0;
       display: block;
       float: left;
+      height: 32px;
+      margin: 0 1rem 0 0;
       vertical-align: middle;
     }
   }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -8,7 +8,7 @@
 
   .p-navigation {
     background: $color-x-light;
-    border-bottom: 1px solid $color-mid-dark;
+    border-bottom: 1px solid $color-mid-light;
     color: $color-dark;
     line-height: 32px;
     padding: 7.5px 0;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -14,12 +14,12 @@
     padding: 7.5px 0;
 
 
-    .p-navigation__link {
+    &__link {
       color: $color-dark;
       margin: 0;
 
       &:visited {
-        color: $color-mid-dark;
+        color: $color-dark;
       }
     }
 

--- a/scss/_patterns_sidebar-nav.scss
+++ b/scss/_patterns_sidebar-nav.scss
@@ -62,7 +62,7 @@
 
 
     &__group {
-      border-bottom: 1px dotted $color-mid-dark;
+      border-bottom: 1px dotted $color-mid-light;
       margin: 0;
       padding: 1rem;
 

--- a/scss/_patterns_sidebar-nav.scss
+++ b/scss/_patterns_sidebar-nav.scss
@@ -19,19 +19,36 @@
 
     &__list &__list &__link {
       display: inline-block;
-      padding-left: 1rem;
     }
 
     &__list &__list &__list &__link {
-      padding-left: 2rem;
+      padding-left: 1rem;
     }
 
     &__link {
       border-bottom: 0;
+      color: $text-color;
+      font-weight: 300;
       margin-bottom: .5rem;
 
+      &:visited {
+        color: $text-color;
+      }
+
+      &:hover {
+        color: $link-color;
+      }
+
+      &:visited {
+        color: $color-dark;
+      }
+
+      &:hover {
+        color: $color-information;
+      }
+
       &.is-active {
-        border-left: 3px solid $color-brand;
+        font-weight: normal;
       }
     }
 

--- a/scss/_patterns_toc.scss
+++ b/scss/_patterns_toc.scss
@@ -4,5 +4,19 @@
     list-style: none;
     margin: 0;
     padding: 0;
+
+    &__link {
+      border-bottom: 0;
+      color: $text-color;
+      margin-bottom: .5rem;
+
+      &:visited {
+        color: $text-color;
+      }
+
+      &:hover {
+        color: $link-color;
+      }
+    }
   }
 }

--- a/scss/_patterns_toc.scss
+++ b/scss/_patterns_toc.scss
@@ -1,22 +1,8 @@
 // Table of contents pattern
 @mixin docs-p-toc {
   .p-toc {
-    @media (min-width: $breakpoint-medium) {
-      border-left: 1px solid $color-dark;
-      padding-left: 1rem;
-    }
-
-    &__header {
-      color: $color-mid-dark;
-      font-size: .875rem;
-      margin-bottom: .5rem;
-      text-transform: uppercase;
-    }
-
-    &__list {
-      list-style: none;
-      margin: 0;
-      padding: 0 0 1rem;
-    }
+    list-style: none;
+    margin: 0;
+    padding: 0;
   }
 }

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -1,0 +1,10 @@
+// Import settings from vanilla
+@import 'vanilla-framework/scss/settings_assets';
+@import 'vanilla-framework/scss/settings_breakpoints';
+@import 'vanilla-framework/scss/settings_colors';
+@import 'vanilla-framework/scss/settings_font';
+@import 'vanilla-framework/scss/settings_grid';
+
+// Theme settings
+$link-color: $color-information !default;
+$text-color: $color-dark !default;

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -1,9 +1,5 @@
 // Settings
-@import 'vanilla-framework/scss/settings_assets';
-@import 'vanilla-framework/scss/settings_breakpoints';
-@import 'vanilla-framework/scss/settings_colors';
-@import 'vanilla-framework/scss/settings_font';
-@import 'vanilla-framework/scss/settings_grid';
+@import 'settings';
 
 // Import Vanilla base styles
 @import 'vanilla-framework/scss/base_blockquotes';
@@ -21,6 +17,7 @@
 
 // import theme patterns
 @import 'base_code';
+@import 'base_links';
 @import 'patterns_aside';
 @import 'patterns_layout';
 @import 'patterns_navigation';
@@ -46,6 +43,7 @@
 
   // Theme patterns
   @include docs-b-code;
+  @include docs-b-links;
   @include docs-p-aside;
   @include docs-p-layout;
   @include docs-p-footer;

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -19,6 +19,7 @@
 @import 'base_code';
 @import 'base_links';
 @import 'patterns_aside';
+@import 'patterns_breadcrumbs';
 @import 'patterns_layout';
 @import 'patterns_navigation';
 @import 'patterns_footer';
@@ -45,6 +46,7 @@
   @include docs-b-code;
   @include docs-b-links;
   @include docs-p-aside;
+  @include docs-p-breadcrumbs;
   @include docs-p-layout;
   @include docs-p-footer;
   @include docs-p-grid;

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -21,6 +21,7 @@
 
 // import theme patterns
 @import 'base_code';
+@import 'patterns_aside';
 @import 'patterns_layout';
 @import 'patterns_navigation';
 @import 'patterns_footer';
@@ -45,6 +46,7 @@
 
   // Theme patterns
   @include docs-b-code;
+  @include docs-p-aside;
   @include docs-p-layout;
   @include docs-p-footer;
   @include docs-p-grid;


### PR DESCRIPTION
*Please merge #42 first*

Bring over the breadcrumbs pattern that's already on <http://docs.ubuntu.com/core/en/>.

QA
--

*Please merge #42 first*

`npm i`, `gulp build` and open `demo/index.html`.

Check breadcrumbs exist in small screen, above content heading. Note, the lack of space between heading and breadcrumbs is expected and is fixed by #37.

Check breadcrumbs don't show in large screen.