### PR TITLE
Update header height and logo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -13,6 +13,7 @@
     <header class="p-navigation" role="banner">
         <div class="p-navigation__logo">
             <a class="p-navigation__link" href="#">
+                <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="Documentation logo">
                 vanilla docs theme
             </a>
         </div>

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -10,7 +10,9 @@
     background: $color-x-light;
     border-bottom: 1px solid $color-mid-dark;
     color: $color-dark;
-    padding: .5rem 0;
+    line-height: 32px;
+    padding: 7.5px 0;
+
 
     .p-navigation__link {
       color: $color-dark;
@@ -21,8 +23,18 @@
       }
     }
 
-    .p-navigation__logo {
+    &__logo {
       color: $color-dark;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+
+    &__image {
+      height: 32px;
+      margin: 0 1rem 0 0;
+      display: block;
+      float: left;
+      vertical-align: middle;
     }
   }
 }


### PR DESCRIPTION
As per #35:

- Make header title always 32px high
- Make logo always 32 px high
- Make whole header always 48px high
- Remove extra margin around image in mobile view

QA
--

`npm i`, `gulp build`, open `demo/index.html`. See the logo & header looks sane and always 48px high in both large and small screen.