### PR TITLE
Add expand and collapse icons

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -24,7 +24,10 @@
                 <ul class="p-sidebar-nav__list">
                     <li class="p-sidebar-nav__group">
                         <a href="#section1">
-                            <h4 class="p-sidebar-nav__header">Section title 1</h4>
+                            <h4 class="p-sidebar-nav__header">
+                                <img class="p-sidebar-nav__toggle--collapse" src="https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg" />
+                                Section title 1
+                            </h4>
                         </a>
                         <section id="section1" class="p-sidebar-nav__section">
                             <ul class="p-sidebar-nav__list">
@@ -42,9 +45,12 @@
                     </li>
                     <li class="p-sidebar-nav__group">
                         <a href="#section2">
-                            <h4 class="p-sidebar-nav__header">Section title 2</h4>
+                            <h4 class="p-sidebar-nav__header">
+                                <img class="p-sidebar-nav__toggle--expand" src="https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg" />
+                                Section title 2
+                            </h4>
                         </a>
-                        <section id="section2" class="p-sidebar-nav__section">
+                        <section id="section2" class="p-sidebar-nav__section--collapsed">
                             <ul class="p-sidebar-nav__list">
                                 <li>
                                     <a class="p-sidebar-nav__link" href="#4">Adipisicing elit</a>
@@ -101,6 +107,8 @@
                             <section id="section4" class="p-sidebar-nav__section">
                                 <ul class="p-sidebar-nav__list">
                                     <li>
+                                        <img class="p-sidebar-nav__toggle--collapse" src="https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg" />
+
                                         <a class="p-sidebar-nav__link" href="#16">Elit quo</a>
 
                                         <section id="section5" class="p-sidebar-nav__section">
@@ -115,7 +123,20 @@
                                         </section>
                                     </li>
                                     <li>
+                                        <img class="p-sidebar-nav__toggle--expand" src="https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg" />
+
                                         <a class="p-sidebar-nav__link" href="#19">Adipisicing eiciendis</a>
+
+                                        <section id="section5" class="p-sidebar-nav__section--collapsed">
+                                            <ul class="p-sidebar-nav__list">
+                                                <li>
+                                                    <a class="p-sidebar-nav__link" href="#17">Lorem quo</a>
+                                                </li>
+                                                <li>
+                                                    <a class="p-sidebar-nav__link" href="#18">Dolor eisciendis</a>
+                                                </li>
+                                            </ul>
+                                        </section>
                                     </li>
                                     <li>
                                         <a class="p-sidebar-nav__link" href="#20">Quo magnam eiciendis</a>

--- a/scss/_patterns_sidebar-nav.scss
+++ b/scss/_patterns_sidebar-nav.scss
@@ -1,3 +1,10 @@
+%p-sidebar-nav-toggle {
+  cursor: pointer;
+  float: right;
+  padding: .5em 0;
+  width: .6em;
+}
+
 @mixin docs-p-sidebar-nav {
   .p-sidebar-nav {
     margin: 0 auto;
@@ -27,6 +34,32 @@
         border-left: 3px solid $color-brand;
       }
     }
+
+    &__toggle--expand {
+      @extend %p-sidebar-nav-toggle;
+    }
+
+    &__toggle--collapse {
+      @extend %p-sidebar-nav-toggle;
+      filter: FlipV;
+      transform: scaleY(-1);
+    }
+
+    &__header {
+      @media (min-width: $breakpoint-medium) {
+        font-size: 1.3125rem;
+      }
+      margin-bottom: 0;
+    }
+
+    &__header + &__section {
+      margin-top: 1rem;
+    }
+
+    &__section--collapsed {
+      display: none;
+    }
+
 
     &__group {
       border-bottom: 1px dotted $color-mid-dark;


### PR DESCRIPTION
As per #35:

- Add styles for expand and collapse buttons on menu items
- Add examples of expand and collapse buttons and some collapsed sections into markup in the demo page
- The buttons won't actually work - they should be implemented with JavaScript by the user

QA
--

`npm i`, `gulp build` and open `build/index.html`.

See the expand/collapse buttons on some of the menu items. See that some menu sections are collapsed. Check it all looks good in both large and small screens.